### PR TITLE
WebPreferences fix so "Conf" directory is correct

### DIFF
--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebPreferences.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebPreferences.cpp
@@ -258,7 +258,7 @@ void WebPreferences::clearAllCertificatesInfo()
 
 const char* WebPreferences::valueForKey(const char* key)
 {
-    string value = m_privatePrefs[key];
+    string &value = m_privatePrefs[key];
     return value.c_str();
 }
 
@@ -269,7 +269,7 @@ void WebPreferences::setValueForKey(const char* key, const char* value)
 
 const char* WebPreferences::stringValueForKey(const char* key)
 {
-    string value = m_privatePrefs[key];
+    string &value = m_privatePrefs[key];
     return value.c_str();
 }
 


### PR DESCRIPTION
This fixes a dangling pointer issue with WebPreferences, which was responsible for the "Conf" directory string becoming random garbage when compiling with GCC 8.3.0.